### PR TITLE
catgram: v2.5.1でnode-sassがうまく動作しなくなった問題への対処

### DIFF
--- a/Dockerfile-catgram
+++ b/Dockerfile-catgram
@@ -1,4 +1,4 @@
-FROM node:8.11.3 as node
+FROM node:8.11-stretch as node
 FROM ruby:2.5
 
 LABEL maintainer="https://github.com/tri-star/mastodon" \


### PR DESCRIPTION
(linux/musl版を探そうとするので、debian stretch版のnodeイメージを指定するように変更)